### PR TITLE
fix(ui): add aria-labels to input elements for better accessibility

### DIFF
--- a/src/components/CustomDialog.jsx
+++ b/src/components/CustomDialog.jsx
@@ -46,6 +46,7 @@ export const CustomDialog = ({ dialog, onClose }) => {
             {dialog.type === 'prompt' && (
                 <input
                     autoFocus
+                    aria-label={dialog.message || dialog.title}
                     value={inputVal}
                     onChange={(e) => setInputVal(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}

--- a/src/components/SafeMarkdown.test.jsx
+++ b/src/components/SafeMarkdown.test.jsx
@@ -14,8 +14,10 @@ describe('SafeMarkdown Component (Lazy & Suspense)', () => {
         const markdown = '# Hello World\nThis is **bold** text';
         render(<SafeMarkdown>{markdown}</SafeMarkdown>);
 
-        const heading = await screen.findByText('Hello World');
-        expect(heading.tagName).toBe('H1');
+        await waitFor(() => {
+            const heading = screen.getByRole('heading', { level: 1 });
+            expect(heading).toHaveTextContent('Hello World');
+        });
     });
 
     it('renders bold text correctly after loading', async () => {

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -68,6 +68,7 @@ export const DeckOverview = ({ questions, stats, onMarkQuestion }) => {
                         <input
                             type="text"
                             placeholder="Search questions..."
+                            aria-label="Search questions"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
                             className="w-full pl-10 pr-4 py-2 bg-slate-50 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 outline-none transition-colors dark:text-white"

--- a/src/components/features/SidebarControls.jsx
+++ b/src/components/features/SidebarControls.jsx
@@ -199,6 +199,7 @@ export const SidebarControls = ({
                             <input
                                 type="checkbox"
                                 className="sr-only peer"
+                                aria-label="Toggle Spaced Repetition"
                                 checked={settings.srsEnabled || false}
                                 onChange={(e) =>
                                     onSettingsChange({ ...settings, srsEnabled: e.target.checked })


### PR DESCRIPTION
Added `aria-label` attributes to several input elements across the application to improve accessibility for screen reader users.

- Added `aria-label="Search questions"` to the search input in `DeckOverview.jsx`.
- Added `aria-label={dialog.message || dialog.title}` to the prompt input in `CustomDialog.jsx`.
- Added `aria-label="Toggle Spaced Repetition"` to the SRS toggle checkbox in `SidebarControls.jsx`.
- Fixed a failing test in `SafeMarkdown.test.jsx` by using `getByRole` for a more robust check.

These small additions enhance keyboard navigation and screen reader support without changing visual behavior or layout.

---
*PR created automatically by Jules for task [14779061160731882762](https://jules.google.com/task/14779061160731882762) started by @Tugamer89*