### PR TITLE
perf: Wrap SafeMarkdown with React.memo

### DIFF
--- a/src/components/SafeMarkdown.jsx
+++ b/src/components/SafeMarkdown.jsx
@@ -12,7 +12,6 @@ const MarkdownPlaceholder = () => (
     <div className="h-4 w-full max-w-50 bg-slate-100 dark:bg-slate-700 animate-pulse rounded mt-1" />
 );
 
-// perf: Wrapped SafeMarkdown in React.memo to prevent unnecessary re-renders of expensive markdown parsing, especially during live session text input or expanding/collapsing questions
 const SafeMarkdown = memo(function SafeMarkdown({
     children,
     remarkPlugins = [],

--- a/src/components/SafeMarkdown.jsx
+++ b/src/components/SafeMarkdown.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, memo } from 'react';
 import PropTypes from 'prop-types';
 import { ErrorBoundary } from './ErrorBoundary';
 import remarkGfm from 'remark-gfm';
@@ -12,7 +12,8 @@ const MarkdownPlaceholder = () => (
     <div className="h-4 w-full max-w-50 bg-slate-100 dark:bg-slate-700 animate-pulse rounded mt-1" />
 );
 
-export default function SafeMarkdown({
+// perf: Wrapped SafeMarkdown in React.memo to prevent unnecessary re-renders of expensive markdown parsing, especially during live session text input or expanding/collapsing questions
+const SafeMarkdown = memo(function SafeMarkdown({
     children,
     remarkPlugins = [],
     rehypePlugins = [],
@@ -34,7 +35,7 @@ export default function SafeMarkdown({
             </Suspense>
         </ErrorBoundary>
     );
-}
+});
 
 SafeMarkdown.propTypes = {
     children: PropTypes.string.isRequired,
@@ -42,3 +43,5 @@ SafeMarkdown.propTypes = {
     remarkPlugins: PropTypes.array,
     rehypePlugins: PropTypes.array,
 };
+
+export default SafeMarkdown;


### PR DESCRIPTION
What: Wrapped the `SafeMarkdown` component with `React.memo()`.
Why: Markdown parsing is an expensive operation. In the `LiveSession` and `DeckOverview` components, `SafeMarkdown` was being re-rendered unnecessarily when parent components updated (e.g., when a user is typing a text answer).
Impact: Prevents expensive rendering operations on components when text updates are typed. This will result in a more responsive UI during these sessions.
Measurement: Compare UI responsiveness before and after typing in the text field during a live session.

---
*PR created automatically by Jules for task [7619902921970907758](https://jules.google.com/task/7619902921970907758) started by @Tugamer89*