### PR TITLE
perf: replace O(n2) nested loop with O(n) hash map lookup in mergeQuestions

### DIFF
--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -14,10 +14,16 @@ export const setQuestionStatus = (questionId, newStatus) => (prevQuestions) =>
     prevQuestions.map((q) => (q.id === questionId ? { ...q, status: newStatus } : q));
 
 export function mergeQuestions(prevQuestions, parsed, currentDeckId) {
+    // perf: Replace O(n²) nested loop with O(n) hash map lookup for merging questions
+    const existingMap = new Map();
+    for (const q of prevQuestions) {
+        if (q.deckId === currentDeckId) {
+            existingMap.set(q.text, q);
+        }
+    }
+
     return parsed.map((newQ) => {
-        const existing = prevQuestions.find(
-            (q) => q.text === newQ.text && q.deckId === currentDeckId
-        );
+        const existing = existingMap.get(newQ.text);
         if (existing) {
             return { ...newQ, status: existing.status, id: existing.id, deckId: currentDeckId };
         }


### PR DESCRIPTION
What: Replaced the `.find()` method inside the `.map()` loop in `mergeQuestions` with an `O(N)` hash map approach.

Why: The previous implementation had an `O(N * M)` time complexity which could cause main thread blocking and lag when users type and the function merges large lists of questions.

Impact: Reduces time complexity from `O(N * M)` to `O(N + M)`, drastically reducing processing time for large decks and eliminating potential UI lag during typing.

Measurement: Can be verified by using a large text block of questions in the raw text box and observing typing responsiveness, or by checking the execution time of `mergeQuestions` for arrays larger than a few hundred items.

---
*PR created automatically by Jules for task [17945235121183581322](https://jules.google.com/task/17945235121183581322) started by @Tugamer89*