### PR TITLE
feat(ui): improve disabled buttons UX with tooltips and visual feedback

### DIFF
--- a/src/components/features/SidebarControls.jsx
+++ b/src/components/features/SidebarControls.jsx
@@ -161,7 +161,8 @@ export const SidebarControls = ({
                     <button
                         onClick={onCopyText}
                         disabled={!currentRawText}
-                        className="flex-1 flex items-center justify-center space-x-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300 disabled:opacity-50 font-medium py-2 px-4 rounded-lg transition-colors text-sm"
+                        title={!currentRawText ? "Add text to copy" : "Copy text"}
+                        className="flex-1 flex items-center justify-center space-x-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed font-medium py-2 px-4 rounded-lg transition-colors text-sm"
                     >
                         <Copy className="w-4 h-4" /> <span>Copy</span>
                     </button>
@@ -169,8 +170,8 @@ export const SidebarControls = ({
                         onClick={onClearText}
                         disabled={!currentRawText}
                         aria-label="Erase all text"
-                        title="Clear"
-                        className="flex-none p-2.5 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/80 disabled:opacity-50 rounded-lg transition-colors"
+                        title={!currentRawText ? "Add text to clear" : "Clear"}
+                        className="flex-none p-2.5 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/80 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
                     >
                         <Eraser className="w-5 h-5" />
                     </button>
@@ -305,7 +306,8 @@ export const SidebarControls = ({
                     <button
                         onClick={onGenerateQuiz}
                         disabled={activeDeckQuestionsLength === 0}
-                        className="w-full mt-4 flex items-center justify-center space-x-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:text-slate-500 text-white font-medium py-3 px-4 rounded-lg transition-all shadow-sm active:scale-[0.98]"
+                        title={activeDeckQuestionsLength === 0 ? "Add questions to this deck to start a quiz" : "Start Quiz"}
+                        className="w-full mt-4 flex items-center justify-center space-x-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-lg transition-all shadow-sm active:scale-[0.98]"
                     >
                         <Play className="w-5 h-5 fill-current" />
                         <span>Start Quiz</span>


### PR DESCRIPTION
This PR introduces a small micro-UX enhancement by improving the state feedback of disabled buttons.

**What:**
Added dynamic `title` tooltips and the `disabled:cursor-not-allowed` Tailwind class to the "Copy", "Clear", and "Start Quiz" buttons in the sidebar.

**Why:**
Previously, when these buttons were disabled, there was no explanation as to why. By adding dynamic tooltips (e.g., "Add questions to this deck to start a quiz"), we provide actionable guidance to the user. The `cursor-not-allowed` style gives immediate visual confirmation that the element is inactive, improving overall usability and accessibility.

**Accessibility:**
- Tooltips provide context for disabled states, assisting all users, including those using assistive technologies, to understand the current UI context.

---
*PR created automatically by Jules for task [1022194776088350667](https://jules.google.com/task/1022194776088350667) started by @Tugamer89*