### PR TITLE
perf: memoize ActivityHeatmap to prevent re-renders

### DIFF
--- a/src/components/features/ActivityHeatmap.jsx
+++ b/src/components/features/ActivityHeatmap.jsx
@@ -67,7 +67,6 @@ const getCurrentStreak = (deckLog, todayDate, todayStr) => {
     return streak;
 };
 
-// perf: Wrapped ActivityHeatmap in React.memo to prevent unnecessary re-renders when parent state changes (e.g., when user is typing in SidebarControls)
 export const ActivityHeatmap = memo(({ deckLog = {} }) => {
     const COLUMNS = 104;
 

--- a/src/components/features/ActivityHeatmap.jsx
+++ b/src/components/features/ActivityHeatmap.jsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import PropTypes from 'prop-types';
 import { Flame, Activity } from 'lucide-react';
 import { getLocalYYYYMMDD } from '../../utils/helpers';
@@ -67,7 +67,8 @@ const getCurrentStreak = (deckLog, todayDate, todayStr) => {
     return streak;
 };
 
-export const ActivityHeatmap = ({ deckLog = {} }) => {
+// perf: Wrapped ActivityHeatmap in React.memo to prevent unnecessary re-renders when parent state changes (e.g., when user is typing in SidebarControls)
+export const ActivityHeatmap = memo(({ deckLog = {} }) => {
     const COLUMNS = 104;
 
     const { days, currentStreak, totalCards, monthLabels } = useMemo(() => {
@@ -193,7 +194,7 @@ export const ActivityHeatmap = ({ deckLog = {} }) => {
             </div>
         </div>
     );
-};
+});
 
 ActivityHeatmap.propTypes = {
     deckLog: PropTypes.object,


### PR DESCRIPTION
What:
Wrapped ActivityHeatmap in React.memo() to prevent unnecessary re-renders.

Why:
ActivityHeatmap recalculates a large amount of visual data. It was being rendered alongside SidebarControls which has a raw text input field that causes frequent state updates while typing. Because ActivityHeatmap only depends on `deckLog`, it does not need to re-render when text is being typed.

Impact:
Reduces unnecessary re-renders of the ActivityHeatmap when typing in the text area in the SidebarControls, making typing noticeably smoother and more efficient.

Measurement:
Verify that ActivityHeatmap does not re-render when modifying raw text in the sidebar. This can be done with the React DevTools profiler or simple `console.log` trace.

---
*PR created automatically by Jules for task [6351342615299085762](https://jules.google.com/task/6351342615299085762) started by @Tugamer89*