### PR TITLE
feat(ui): improve accessibility for question expand button

### DIFF
--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -127,9 +127,14 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
                                 <button
                                     type="button"
                                     title="Expand question to see answer"
+                                    aria-label={
+                                        expandedId === q.id
+                                            ? 'Collapse question'
+                                            : 'Expand question to see answer'
+                                    }
                                     aria-expanded={expandedId === q.id}
                                     onClick={() => toggleExpand(q.id)}
-                                    className="flex-1 min-w-0 text-left focus:outline-none rounded-lg p-1 -m-1"
+                                    className="flex-1 min-w-0 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:focus-visible:ring-indigo-400 rounded-lg p-1 -m-1 transition-shadow"
                                 >
                                     <div className="text-sm font-medium text-slate-800 dark:text-slate-200 flex items-start gap-2 overflow-hidden">
                                         {expandedId === q.id ? (


### PR DESCRIPTION
What: Added a dynamic `aria-label` (toggling between "Expand question" and "Collapse question") and visible focus rings to the question toggle button in `DeckOverview.jsx`.
Why: It improves accessibility for keyboard users and screen readers, ensuring that interactive elements are clearly identifiable and their current state is announced.
Before/After: Visually, a focus ring appears when the element is tabbed to using a keyboard. Screen readers now describe the element's purpose and state.
Accessibility: Improved ARIA labels and focus visibility.

---
*PR created automatically by Jules for task [2742291002558023325](https://jules.google.com/task/2742291002558023325) started by @Tugamer89*