### PR TITLE
perf: optimize DeckOverview question filtering

### DIFF
--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -27,7 +27,6 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
     }, [questions]);
 
     const filteredQuestions = useMemo(() => {
-        // perf: Add early return to skip unnecessary processing when no filters are applied
         if (!searchTerm && selectedTags.length === 0) {
             return questions;
         }

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -27,12 +27,19 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
     }, [questions]);
 
     const filteredQuestions = useMemo(() => {
+        // perf: Add early return to skip unnecessary processing when no filters are applied
+        if (!searchTerm && selectedTags.length === 0) {
+            return questions;
+        }
+
         const searchLower = searchTerm.toLowerCase();
         return questions.filter((q) => {
             const matchesSearch =
+                !searchTerm ||
                 q.text.toLowerCase().includes(searchLower) ||
-                q.answer.toLowerCase().includes(searchLower);
-            const matchesTag = selectedTags.every((t) => q.tags?.includes(t));
+                (q.answer && q.answer.toLowerCase().includes(searchLower));
+            const matchesTag =
+                selectedTags.length === 0 || selectedTags.every((t) => q.tags?.includes(t));
             return matchesSearch && matchesTag;
         });
     }, [questions, searchTerm, selectedTags]);

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -37,9 +37,8 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
             const matchesSearch =
                 !searchTerm ||
                 q.text.toLowerCase().includes(searchLower) ||
-                (q.answer && q.answer.toLowerCase().includes(searchLower));
-            const matchesTag =
-                selectedTags.length === 0 || selectedTags.every((t) => q.tags?.includes(t));
+                q.answer?.toLowerCase().includes(searchLower);
+            const matchesTag = selectedTags.every((t) => q.tags?.includes(t));
             return matchesSearch && matchesTag;
         });
     }, [questions, searchTerm, selectedTags]);


### PR DESCRIPTION
What:
Added an early return to the `filteredQuestions` `useMemo` block in `DeckOverview.jsx` to skip filtering logic when no filters are active, and added short-circuit logic inside the filter loop.

Why:
To prevent unnecessary O(N) array iterations and expensive string `.toLowerCase()` conversions when the user hasn't typed a search term or selected any tags, which is the default and most common state.

Impact:
Changes O(N) filtering operation to O(1) when no filters are applied. Reduces unnecessary re-renders downstream by returning the same reference instead of a newly allocated array.

Measurement:
Verified that the DeckOverview behaves exactly the same functionally with and without filters applied. Unit tests confirm no regressions.

---
*PR created automatically by Jules for task [2766825410660297242](https://jules.google.com/task/2766825410660297242) started by @Tugamer89*