### PR TITLE
feat(ui): add focus-visible styles to settings checkboxes

### DIFF
--- a/src/components/features/SidebarControls.jsx
+++ b/src/components/features/SidebarControls.jsx
@@ -206,7 +206,7 @@ export const SidebarControls = ({
                                     onSettingsChange({ ...settings, srsEnabled: e.target.checked })
                                 }
                             />
-                            <div className="w-9 h-5 bg-slate-300 peer-focus:outline-none rounded-full peer dark:bg-slate-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-500"></div>
+                            <div className="w-9 h-5 bg-slate-300 peer-focus:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-indigo-500 peer-focus-visible:ring-offset-2 dark:peer-focus-visible:ring-offset-slate-800 rounded-full peer dark:bg-slate-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-indigo-500"></div>
                         </div>
                     </label>
 
@@ -280,7 +280,7 @@ export const SidebarControls = ({
                                                         [key]: e.target.checked,
                                                     })
                                                 }
-                                                className="rounded w-4 h-4 cursor-pointer transition-colors"
+                                                className="rounded w-4 h-4 cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800"
                                             />
                                             <div className="flex justify-between flex-1 text-sm text-slate-600 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
                                                 <span>{displayLabel}</span>


### PR DESCRIPTION
What:
Added explicit focus-visible styles (focus rings) to the custom Spaced Repetition (SRS) toggle switch and the question filter checkboxes in the SidebarControls component.

Why:
These custom UI elements previously lacked visual indicators when focused via keyboard navigation (e.g., using the Tab key), making it difficult for keyboard users and screen reader users to track their current position within the quiz setup controls.

Before/After:
Before this change, pressing Tab to navigate to the SRS toggle or the filter checkboxes produced no visual feedback. After this change, a clear indigo focus ring is applied when these elements receive keyboard focus, ensuring consistent accessibility.

Accessibility:
Improves WCAG 2.1 Focus Visible (2.4.7) compliance. Users navigating via keyboard can now clearly see when they have focused the custom toggle switch or filter checkboxes.

---
*PR created automatically by Jules for task [5111591135988821901](https://jules.google.com/task/5111591135988821901) started by @Tugamer89*