### PR TITLE
fix(security): [security improvement] delegate url sanitization to rehype-sanitize

### DIFF
--- a/src/components/SafeMarkdownCore.jsx
+++ b/src/components/SafeMarkdownCore.jsx
@@ -24,9 +24,6 @@ export default function SafeMarkdownCore({ children, remarkPlugins, rehypePlugin
     const preRemoveWrapper = ({ children }) => <>{children}</>;
 
     const aRemoveWrapper = ({ href, ...rest }) => {
-        if (href?.trim().toLowerCase().startsWith('javascript:')) {
-            return <a target="_blank" rel="noopener noreferrer" {...rest} />;
-        }
         return <a href={href} target="_blank" rel="noopener noreferrer" {...rest} />;
     };
 


### PR DESCRIPTION
Severity: LOW
Vulnerability: Code redundancy in security filtering.
Impact: Maintenance overhead and potential confusion, as manual URL protocol checks were redundantly implemented alongside a dedicated sanitization library.
Fix: Removed the manual `javascript:` prefix check in `aRemoveWrapper` (`SafeMarkdownCore.jsx`) to fully delegate URL sanitization to `rehype-sanitize`.
Verification: Verified by running the existing vitest suite (`pnpm run test:run`) which already includes tests that confirm `javascript:` and `vbscript:` protocols are successfully blocked by `rehype-sanitize`.

---
*PR created automatically by Jules for task [10091251314848457496](https://jules.google.com/task/10091251314848457496) started by @Tugamer89*