### PR TITLE
perf: memoize generateQuiz to prevent SidebarControls re-renders

### DIFF
--- a/src/hooks/useQuizSession.js
+++ b/src/hooks/useQuizSession.js
@@ -20,7 +20,9 @@ export function useQuizSession(
     });
     const [showAnswer, setShowAnswer] = useState(false);
 
-    const generateQuiz = () => {
+    // perf: Memoize generateQuiz with useCallback to prevent unnecessary re-renders
+    // of child components (like SidebarControls) that receive this function as a prop.
+    const generateQuiz = useCallback(() => {
         const eligible = questions.filter((q) => {
             if (q.deckId !== selectedDeckId) return false;
 
@@ -65,7 +67,7 @@ export function useQuizSession(
             partiallyCorrectCount: 0,
         });
         setShowAnswer(false);
-    };
+    }, [questions, selectedDeckId, settings, showToast]);
 
     const handleAnswer = (answerStatus) => {
         const currentQ = quizSession.questions[quizSession.currentIndex];

--- a/src/hooks/useQuizSession.js
+++ b/src/hooks/useQuizSession.js
@@ -20,8 +20,6 @@ export function useQuizSession(
     });
     const [showAnswer, setShowAnswer] = useState(false);
 
-    // perf: Memoize generateQuiz with useCallback to prevent unnecessary re-renders
-    // of child components (like SidebarControls) that receive this function as a prop.
     const generateQuiz = useCallback(() => {
         const eligible = questions.filter((q) => {
             if (q.deckId !== selectedDeckId) return false;


### PR DESCRIPTION
### What
Wrapped the `generateQuiz` function inside the `useQuizSession` hook with `useCallback` and the appropriate dependency array (`[questions, selectedDeckId, settings, showToast]`).

### Why
The `generateQuiz` function is passed down as a prop to the `SidebarControls` component. Without memoization, `generateQuiz` is recreated on every render of the parent component using the hook. This causes `SidebarControls` (even though it's wrapped in `React.memo`) to unnecessarily re-render whenever the `useQuizSession` hook's state updates, degrading performance.

### Impact
Prevents unnecessary re-renders of the `SidebarControls` component and its children, leading to a smoother user interface experience, especially when navigating or interacting with the application.

### Measurement
Verify by running the application locally (`pnpm run dev`) and observing the React Developer Tools Profiler. Interactions that update the `useQuizSession` state (but not the dependencies of `generateQuiz`) will no longer trigger a re-render of `SidebarControls`.

---
*PR created automatically by Jules for task [14737178964430815908](https://jules.google.com/task/14737178964430815908) started by @Tugamer89*