### PR TITLE
perf: memoize react-markdown plugin arrays to prevent unnecessary re-renders

### DIFF
--- a/src/components/SafeMarkdown.jsx
+++ b/src/components/SafeMarkdown.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, memo } from 'react';
+import { lazy, Suspense, memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { ErrorBoundary } from './ErrorBoundary';
 import remarkGfm from 'remark-gfm';
@@ -12,22 +12,27 @@ const MarkdownPlaceholder = () => (
     <div className="h-4 w-full max-w-50 bg-slate-100 dark:bg-slate-700 animate-pulse rounded mt-1" />
 );
 
+const defaultRemark = [remarkGfm, remarkMath];
+const defaultRehype = [rehypeKatex, rehypeRaw];
+const EMPTY_ARRAY = [];
+
 const SafeMarkdown = memo(function SafeMarkdown({
     children,
-    remarkPlugins = [],
-    rehypePlugins = [],
+    remarkPlugins = EMPTY_ARRAY,
+    rehypePlugins = EMPTY_ARRAY,
     ...rest
 }) {
-    const defaultRemark = [remarkGfm, remarkMath];
-    const defaultRehype = [rehypeKatex, rehypeRaw];
+    // Memoize the combined plugins to prevent unnecessary re-renders of the heavy markdown core
+    const combinedRemark = useMemo(() => [...defaultRemark, ...remarkPlugins], [remarkPlugins]);
+    const combinedRehype = useMemo(() => [...defaultRehype, ...rehypePlugins], [rehypePlugins]);
 
     return (
         <ErrorBoundary>
             <Suspense fallback={<MarkdownPlaceholder />}>
                 <SafeMarkdownCore
                     {...rest}
-                    remarkPlugins={[...defaultRemark, ...remarkPlugins]}
-                    rehypePlugins={[...defaultRehype, ...rehypePlugins]}
+                    remarkPlugins={combinedRemark}
+                    rehypePlugins={combinedRehype}
                 >
                     {children}
                 </SafeMarkdownCore>

--- a/src/components/SafeMarkdown.jsx
+++ b/src/components/SafeMarkdown.jsx
@@ -22,7 +22,6 @@ const SafeMarkdown = memo(function SafeMarkdown({
     rehypePlugins = EMPTY_ARRAY,
     ...rest
 }) {
-    // Memoize the combined plugins to prevent unnecessary re-renders of the heavy markdown core
     const combinedRemark = useMemo(() => [...defaultRemark, ...remarkPlugins], [remarkPlugins]);
     const combinedRehype = useMemo(() => [...defaultRehype, ...rehypePlugins], [rehypePlugins]);
 

--- a/src/components/SafeMarkdownCore.jsx
+++ b/src/components/SafeMarkdownCore.jsx
@@ -1,41 +1,48 @@
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import PropTypes from 'prop-types';
 import CodeRenderer from './CodeRenderer';
 
+const sanitizeOptions = {
+    ...defaultSchema,
+    attributes: {
+        ...defaultSchema.attributes,
+        code: ['className', ...(defaultSchema.attributes.code || [])],
+        span: ['className', 'style', ...(defaultSchema.attributes.span || [])],
+    },
+    protocols: {
+        ...defaultSchema.protocols,
+        href: ['http', 'https', 'mailto', 'tel'],
+        src: ['http', 'https'],
+        cite: ['http', 'https'],
+    },
+};
+
+const preRemoveWrapper = ({ children }) => <>{children}</>;
+
+const aRemoveWrapper = ({ href, ...rest }) => {
+    return <a href={href} target="_blank" rel="noopener noreferrer" {...rest} />;
+};
+
+const markdownComponents = {
+    code: CodeRenderer,
+    pre: preRemoveWrapper,
+    a: aRemoveWrapper,
+};
+
 export default function SafeMarkdownCore({ children, remarkPlugins, rehypePlugins, ...props }) {
-    const sanitizeOptions = {
-        ...defaultSchema,
-        attributes: {
-            ...defaultSchema.attributes,
-            code: ['className', ...(defaultSchema.attributes.code || [])],
-            span: ['className', 'style', ...(defaultSchema.attributes.span || [])],
-        },
-        protocols: {
-            ...defaultSchema.protocols,
-            href: ['http', 'https', 'mailto', 'tel'],
-            src: ['http', 'https'],
-            cite: ['http', 'https'],
-        },
-    };
-
-    const combinedRehypePlugins = [...(rehypePlugins || []), [rehypeSanitize, sanitizeOptions]];
-
-    const preRemoveWrapper = ({ children }) => <>{children}</>;
-
-    const aRemoveWrapper = ({ href, ...rest }) => {
-        return <a href={href} target="_blank" rel="noopener noreferrer" {...rest} />;
-    };
+    // Memoize plugins to avoid breaking ReactMarkdown's internal memoization
+    const combinedRehypePlugins = useMemo(
+        () => [...(rehypePlugins || []), [rehypeSanitize, sanitizeOptions]],
+        [rehypePlugins]
+    );
 
     return (
         <ReactMarkdown
             remarkPlugins={remarkPlugins}
             rehypePlugins={combinedRehypePlugins}
-            components={{
-                code: CodeRenderer,
-                pre: preRemoveWrapper,
-                a: aRemoveWrapper,
-            }}
+            components={markdownComponents}
             {...props}
         >
             {children}

--- a/src/components/SafeMarkdownCore.jsx
+++ b/src/components/SafeMarkdownCore.jsx
@@ -32,7 +32,6 @@ const markdownComponents = {
 };
 
 export default function SafeMarkdownCore({ children, remarkPlugins, rehypePlugins, ...props }) {
-    // Memoize plugins to avoid breaking ReactMarkdown's internal memoization
     const combinedRehypePlugins = useMemo(
         () => [...(rehypePlugins || []), [rehypeSanitize, sanitizeOptions]],
         [rehypePlugins]


### PR DESCRIPTION
What: Extracted static configuration objects, arrays, and sub-component definitions (`preRemoveWrapper`, `aRemoveWrapper`) outside of the component function, and used `useMemo` for the plugin arrays in `SafeMarkdown.jsx` and `SafeMarkdownCore.jsx`.

Why: The `ReactMarkdown` component was experiencing unnecessary re-renders because its props (like `components`, `remarkPlugins`, `rehypePlugins`) were re-created on every render cycle of its parent component, causing their references to change. This is a significant frontend performance bottleneck for a heavy library like `react-markdown`.

Impact: Eliminates unnecessary deep re-renders of the expensive markdown core library. Fixes the React anti-pattern where defining components inside another component causes them to be fully unmounted and remounted on every render.

Measurement: Verify the improvement using React DevTools Profiler by confirming that `SafeMarkdownCore` components no longer re-render when they are not strictly updated. The test suite has been run and continues to pass successfully.

---
*PR created automatically by Jules for task [13698151292790264086](https://jules.google.com/task/13698151292790264086) started by @Tugamer89*