### PR TITLE
feat(ui): add aria-labels to deck overview tag filters

### DIFF
--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -86,6 +86,7 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
                         <div className="flex flex-wrap gap-2">
                             <button
                                 onClick={() => toggleTag(null)}
+                                aria-label="Show all tags"
                                 className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
                                     selectedTags.length === 0
                                         ? 'bg-indigo-500 text-white'
@@ -98,6 +99,7 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion }) => {
                                 <button
                                     key={tag}
                                     onClick={() => toggleTag(tag)}
+                                    aria-label={`Filter by tag ${tag}`}
                                     className={`px-3 py-1 text-xs font-medium flex items-center rounded-full transition-colors ${
                                         selectedTags.includes(tag)
                                             ? 'bg-indigo-500 text-white'


### PR DESCRIPTION
What: Added `aria-label` attributes to the 'All' and individual tag filter buttons in the Deck Overview component.
Why: The text for tags (e.g., '#frontend') and 'All' provides some context, but an explicit aria-label ('Show all tags', 'Filter by tag #frontend') significantly improves the experience for users relying on screen readers.
Accessibility: Enhanced screen reader accessibility for tag filtering interactions.

---
*PR created automatically by Jules for task [1612683703542362469](https://jules.google.com/task/1612683703542362469) started by @Tugamer89*