### PR TITLE
perf: use shared MutationObserver and cache theme in CodeRenderer

### DIFF
--- a/src/components/CodeRenderer.jsx
+++ b/src/components/CodeRenderer.jsx
@@ -3,34 +3,59 @@ import { PrismAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import PropTypes from 'prop-types';
 
-export default function CodeRenderer({ inline, className, children, ...rest }) {
-    const [isDark, setIsDark] = useState(() => {
-        try {
-            const localTheme = globalThis.localStorage.getItem('quiz_theme_dark');
-            if (localTheme !== null) {
-                return JSON.parse(localTheme);
-            }
-        } catch (e) {
-            console.error(e);
+// perf: Cache initial theme and use shared observer to prevent memory leaks and redundant operations
+let cachedInitialTheme = null;
+let sharedObserver = null;
+const subscribers = new Set();
+
+const getInitialTheme = () => {
+    if (cachedInitialTheme !== null) return cachedInitialTheme;
+    try {
+        const localTheme = globalThis.localStorage.getItem('quiz_theme_dark');
+        if (localTheme !== null) {
+            cachedInitialTheme = JSON.parse(localTheme);
+            return cachedInitialTheme;
         }
-        return document?.documentElement.classList.contains('dark');
+    } catch (e) {
+        console.error(e);
+    }
+    cachedInitialTheme = document?.documentElement.classList.contains('dark');
+    return cachedInitialTheme;
+};
+
+const notifySubscribers = (isDark) => {
+    cachedInitialTheme = isDark;
+    subscribers.forEach((cb) => cb(isDark));
+};
+
+const setupSharedObserver = () => {
+    if (sharedObserver) return;
+    const root = document.documentElement;
+    sharedObserver = new MutationObserver(() => {
+        notifySubscribers(root.classList.contains('dark'));
     });
+    sharedObserver.observe(root, {
+        attributes: true,
+        attributeFilter: ['class'],
+    });
+};
+
+export default function CodeRenderer({ inline, className, children, ...rest }) {
+    const [isDark, setIsDark] = useState(getInitialTheme);
 
     useEffect(() => {
-        const root = document.documentElement;
+        // perf: Skip observing theme changes for inline code block since it relies on CSS classes
+        if (inline) return;
 
-        const checkTheme = () => {
-            setIsDark(root.classList.contains('dark'));
+        setupSharedObserver();
+
+        const handleThemeChange = (dark) => setIsDark(dark);
+        subscribers.add(handleThemeChange);
+
+        return () => {
+            subscribers.delete(handleThemeChange);
         };
-        checkTheme();
-        const observer = new MutationObserver(checkTheme);
-        observer.observe(root, {
-            attributes: true,
-            attributeFilter: ['class'],
-        });
-
-        return () => observer.disconnect();
-    }, []);
+    }, [inline]);
 
     const match = /language-(\w+)/.exec(className || '');
 

--- a/src/components/CodeRenderer.jsx
+++ b/src/components/CodeRenderer.jsx
@@ -3,7 +3,6 @@ import { PrismAsync as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus, vs } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import PropTypes from 'prop-types';
 
-// perf: Cache initial theme and use shared observer to prevent memory leaks and redundant operations
 let cachedInitialTheme = null;
 let sharedObserver = null;
 const subscribers = new Set();
@@ -44,7 +43,6 @@ export default function CodeRenderer({ inline, className, children, ...rest }) {
     const [isDark, setIsDark] = useState(getInitialTheme);
 
     useEffect(() => {
-        // perf: Skip observing theme changes for inline code block since it relies on CSS classes
         if (inline) return;
 
         setupSharedObserver();


### PR DESCRIPTION
What: Refactored CodeRenderer to use a shared MutationObserver and cached the initial theme from localStorage. Skipped MutationObserver subscription for inline code blocks.
Why: Previously, every code block created a new MutationObserver and read from localStorage synchronously, causing memory overhead and slow rendering times for markdown heavy with code blocks.
Impact: Reduces N observers to 1 and N synchronous reads to 1, significantly improving rendering performance.
Measurement: Compare initial render time of a deck with many inline code blocks before and after the change.

---
*PR created automatically by Jules for task [18381810243357487027](https://jules.google.com/task/18381810243357487027) started by @Tugamer89*