### PR TITLE
fix(security): add Permissions-Policy security header

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,6 +19,7 @@ server {
     add_header Referrer-Policy "no-referrer-when-downgrade" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://www.googleapis.com https://*.sentry.io; frame-src 'self' https://accounts.google.com;" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Requests to /quiz-forge naturally resolve to /usr/share/nginx/html/quiz-forge
     location /quiz-forge {


### PR DESCRIPTION
Severity: LOW
Vulnerability: Missing Permissions-Policy HTTP header
Impact: Without this header, the application does not explicitly block access to sensitive browser APIs, which could theoretically be exploited if an attacker found a way to inject malicious code.
Fix: Added the `Permissions-Policy` header to `nginx/nginx.conf` with a policy of `"camera=(), microphone=(), geolocation=(), payment=()"` to explicitly deny access to these features.
Verification: Can be verified by running the application via Nginx (e.g. `docker build -t quiz-forge . && docker run -p 8080:8080 quiz-forge`) and inspecting the HTTP response headers in the browser's developer tools for any request to the server.

---
*PR created automatically by Jules for task [9922458700761661379](https://jules.google.com/task/9922458700761661379) started by @Tugamer89*