### PR TITLE
perf: prevent unnecessary re-renders in quiz components

### DIFF
--- a/src/components/SummaryScreen.jsx
+++ b/src/components/SummaryScreen.jsx
@@ -1,7 +1,9 @@
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import { PieChart, Database, Zap } from 'lucide-react';
 
-export const SummaryScreen = ({ session, onReset, onPlayAgain }) => {
+// perf: Memoize SummaryScreen component to prevent unnecessary re-renders
+export const SummaryScreen = memo(({ session, onReset, onPlayAgain }) => {
     const total = session.questions.length;
     const percentage = Math.round((session.correctCount / total) * 100);
 
@@ -101,7 +103,7 @@ export const SummaryScreen = ({ session, onReset, onPlayAgain }) => {
             </div>
         </div>
     );
-};
+});
 
 SummaryScreen.propTypes = {
     session: PropTypes.shape({

--- a/src/components/features/LiveSession.jsx
+++ b/src/components/features/LiveSession.jsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types';
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback, memo } from 'react';
 import { Play, ArrowRight, XCircle, CheckCircle2, AlertCircle } from 'lucide-react';
 import SafeMarkdown from '../SafeMarkdown';
 import { ProgressBar } from '../ProgressBar';
 import { useShortcuts } from '../../hooks/useShortcuts';
 
-export const LiveSession = ({ session, onCancel, showAnswer, onReveal, onAnswer }) => {
+// perf: Memoize LiveSession component to prevent unnecessary re-renders
+export const LiveSession = memo(({ session, onCancel, showAnswer, onReveal, onAnswer }) => {
     const currentQ = session.questions[session.currentIndex];
     const containerRef = useRef(null);
     const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
@@ -211,7 +212,7 @@ export const LiveSession = ({ session, onCancel, showAnswer, onReveal, onAnswer 
             )}
         </div>
     );
-};
+});
 
 LiveSession.propTypes = {
     session: PropTypes.shape({

--- a/src/hooks/useQuizSession.js
+++ b/src/hooks/useQuizSession.js
@@ -21,7 +21,8 @@ export function useQuizSession(
     });
     const [showAnswer, setShowAnswer] = useState(false);
 
-    const generateQuiz = (options = {}) => {
+    // perf: Wrap generateQuiz and handleAnswer in useCallback to prevent unnecessary re-renders of child components
+    const generateQuiz = useCallback((options = {}) => {
         const isMouseEvent = options && options.nativeEvent instanceof Event;
         const opts = isMouseEvent ? {} : options || {};
         const { includedTags = [], excludedTags = [] } = opts;
@@ -81,9 +82,9 @@ export function useQuizSession(
             lastOptions: opts,
         });
         setShowAnswer(false);
-    };
+    }, [questions, selectedDeckId, settings, showToast]);
 
-    const handleAnswer = (answerStatus) => {
+    const handleAnswer = useCallback((answerStatus) => {
         const currentQ = quizSession.questions[quizSession.currentIndex];
 
         // Spaced Repetition
@@ -142,7 +143,7 @@ export function useQuizSession(
             };
         });
         setShowAnswer(false);
-    };
+    }, [quizSession.questions, quizSession.currentIndex, settings.srsEnabled, selectedDeckId, logActivity, setQuestions]);
 
     const cancelSession = useCallback(() => setQuizSession((p) => ({ ...p, active: false })), []);
     const resetSession = useCallback(


### PR DESCRIPTION
What: Wrapped `SummaryScreen` and `LiveSession` in `React.memo()` and wrapped `generateQuiz` and `handleAnswer` in `useQuizSession` with `useCallback()`.

Why: `generateQuiz` is passed to `DeckOverview` as a prop. Every time the user typed into the Raw Text textbox, the `rawTexts` state changed, which caused `useQuizData` to return a new object, which caused the parent `App` component to re-render, creating a new reference for `generateQuiz` and passing it to `DeckOverview`. This completely negated the `React.memo` wrapping on `DeckOverview` and caused the entire list of questions to re-render on every keystroke, leading to lag when a deck contained many questions.

Impact: Greatly reduces lag while typing raw text by preventing unnecessary `DeckOverview` renders. Prevents unnecessary re-renders of `SummaryScreen` and `LiveSession` from upstream parent state changes.

Measurement: Ensure you are in a deck with dozens of items and type something in the Raw Text field. Observe reduced latency and prevent React DevTools profiling from showing re-renders for the `DeckOverview` component.

---
*PR created automatically by Jules for task [5344838669337005182](https://jules.google.com/task/5344838669337005182) started by @Tugamer89*