### PR TITLE
fix(security): update Referrer-Policy to strict-origin-when-cross-origin

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,7 +16,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://www.googleapis.com https://*.sentry.io; frame-src 'self' https://accounts.google.com;" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;


### PR DESCRIPTION
Severity: LOW/ENHANCEMENT
Vulnerability: The application used `no-referrer-when-downgrade` as its `Referrer-Policy`, which sends the full URL (including potential sensitive path parameters) on cross-origin requests as long as the protocol stays HTTPS.
Impact: If a user clicks an external link or a resource is loaded from an external origin, the full URL of the current page could be leaked in the Referrer header.
Fix: Updated the `Referrer-Policy` header in `nginx/nginx.conf` to `strict-origin-when-cross-origin`. This is a modern security best practice that only sends the origin (domain) on cross-origin requests, thereby protecting potentially sensitive information in the URL path, while maintaining the full URL for same-origin requests.
Verification: Verify the configuration change in `nginx/nginx.conf`.

---
*PR created automatically by Jules for task [7882674915199420593](https://jules.google.com/task/7882674915199420593) started by @Tugamer89*