### PR TITLE
fix(security): [security improvement]

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,7 +18,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://www.googleapis.com https://*.sentry.io; frame-src 'self' https://accounts.google.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://www.googleapis.com https://*.sentry.io; frame-src 'self' https://accounts.google.com; object-src 'none'; base-uri 'none';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
 
     # Requests to /quiz-forge naturally resolve to /usr/share/nginx/html/quiz-forge


### PR DESCRIPTION
Severity: LOW/ENHANCEMENT
Vulnerability: Existing Content-Security-Policy did not explicitly block legacy plugins (Flash, Java) via object-src and allowed base-uri modification.
Impact: While modern browsers and the app structure mitigate much of the risk, explicitly setting object-src 'none' and base-uri 'none' provides defense-in-depth against potential Object injection or Base Tag hijacking attacks.
Fix: Appended `object-src 'none'; base-uri 'none';` to the Content-Security-Policy header in `nginx/nginx.conf`.
Verification: Verified by running the test suite (`pnpm test:run`) which passed successfully.

---
*PR created automatically by Jules for task [12951996023621997931](https://jules.google.com/task/12951996023621997931) started by @Tugamer89*