### PR TITLE
perf: optimize tag filtering and extraction logic

### DIFF
--- a/src/components/SummaryScreen.jsx
+++ b/src/components/SummaryScreen.jsx
@@ -2,7 +2,6 @@ import { memo } from 'react';
 import PropTypes from 'prop-types';
 import { PieChart, LogOut, Zap } from 'lucide-react';
 
-// perf: Memoize SummaryScreen component to prevent unnecessary re-renders
 export const SummaryScreen = memo(({ session, onReset, onPlayAgain }) => {
     const total = session.questions.length;
     const percentage = Math.round((session.correctCount / total) * 100);

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -33,15 +33,18 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
         }
 
         const searchLower = searchTerm.toLowerCase();
+        const includedSet = new Set(includedTags);
+        const excludedSet = new Set(excludedTags);
+
         return questions.filter((q) => {
             const matchesSearch =
                 !searchTerm ||
                 q.text.toLowerCase().includes(searchLower) ||
                 q.answer.toLowerCase().includes(searchLower);
             const matchesIncluded =
-                includedTags.length === 0 || includedTags.some((t) => q.tags?.includes(t));
+                includedSet.size === 0 || q.tags?.some((t) => includedSet.has(t));
             const matchesExcluded =
-                excludedTags.length === 0 || !excludedTags.some((t) => q.tags?.includes(t));
+                excludedSet.size === 0 || !q.tags?.some((t) => excludedSet.has(t));
             return matchesSearch && matchesIncluded && matchesExcluded;
         });
     }, [questions, searchTerm, includedTags, excludedTags]);

--- a/src/components/features/LiveSession.jsx
+++ b/src/components/features/LiveSession.jsx
@@ -5,7 +5,6 @@ import SafeMarkdown from '../SafeMarkdown';
 import { ProgressBar } from '../ProgressBar';
 import { useShortcuts } from '../../hooks/useShortcuts';
 
-// perf: Memoize LiveSession component to prevent unnecessary re-renders
 export const LiveSession = memo(({ session, onCancel, showAnswer, onReveal, onAnswer }) => {
     const currentQ = session.questions[session.currentIndex];
     const containerRef = useRef(null);

--- a/src/hooks/useQuizData.js
+++ b/src/hooks/useQuizData.js
@@ -68,7 +68,7 @@ export function useQuizData(showToast, setDialog) {
     };
 
     const extractTags = (text) => {
-        if (!text) return [];
+        if (!text || !text.includes('#')) return [];
 
         const textWithoutCode = text
             .replaceAll(CODE_BLOCK_REGEX, '')

--- a/src/hooks/useQuizData.js
+++ b/src/hooks/useQuizData.js
@@ -68,7 +68,7 @@ export function useQuizData(showToast, setDialog) {
     };
 
     const extractTags = (text) => {
-        if (!text || !text.includes('#')) return [];
+        if (!text?.includes('#')) return [];
 
         const textWithoutCode = text
             .replaceAll(CODE_BLOCK_REGEX, '')

--- a/src/hooks/useQuizSession.js
+++ b/src/hooks/useQuizSession.js
@@ -21,22 +21,24 @@ export function useQuizSession(
     });
     const [showAnswer, setShowAnswer] = useState(false);
 
-    // perf: Wrap generateQuiz and handleAnswer in useCallback to prevent unnecessary re-renders of child components
     const generateQuiz = useCallback((options = {}) => {
         const isMouseEvent = options && options.nativeEvent instanceof Event;
         const opts = isMouseEvent ? {} : options || {};
         const { includedTags = [], excludedTags = [] } = opts;
 
+        const includedSet = new Set(includedTags);
+        const excludedSet = new Set(excludedTags);
+
         const eligible = questions.filter((q) => {
             if (q.deckId !== selectedDeckId) return false;
 
-            if (includedTags.length > 0) {
-                const hasAnyIncluded = includedTags.some((t) => q.tags?.includes(t));
+            if (includedSet.size > 0) {
+                const hasAnyIncluded = q.tags?.some((t) => includedSet.has(t));
                 if (!hasAnyIncluded) return false;
             }
 
-            if (excludedTags.length > 0) {
-                const hasAnyExcluded = excludedTags.some((t) => q.tags?.includes(t));
+            if (excludedSet.size > 0) {
+                const hasAnyExcluded = q.tags?.some((t) => excludedSet.has(t));
                 if (hasAnyExcluded) return false;
             }
 

--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -14,7 +14,6 @@ export const setQuestionStatus = (questionId, newStatus) => (prevQuestions) =>
     prevQuestions.map((q) => (q.id === questionId ? { ...q, status: newStatus } : q));
 
 export function mergeQuestions(prevQuestions, parsed, currentDeckId) {
-    // perf: Replace O(n²) nested loop with O(n) hash map lookup for merging questions
     const existingMap = new Map();
     for (const q of prevQuestions) {
         if (q.deckId === currentDeckId) {


### PR DESCRIPTION
### What
- Converted `includedTags` and `excludedTags` to `Set` objects in `useQuizSession.js` and `DeckOverview.jsx` for faster O(1) tag lookups instead of O(N) array checks.
- Added an early return check (`!text.includes('#')`) in `extractTags` (`useQuizData.js`) to completely bypass heavy regex evaluations on text blocks without tags.
- Removed all `// perf:` comments from the codebase as requested.

### Why
- Array `.some` combined with `.includes` inside large `.filter` loops creates unnecessary O(N*M) lookup complexity which can slow down quiz generation and rendering on large tag sets.
- `extractTags` performs heavy string `.replaceAll` and regex matching inside an iteration. Doing this on content that has no tags is an unnecessary performance penalty.
- The `// perf:` comments were requested to be removed.

### Impact
- Speeds up deck filtering and custom quiz generation for large sets of questions/tags.
- Reduces CPU overhead on initial content parsing, particularly for large raw texts.

### Measurement
- Run `pnpm run test:run` to ensure all functionality is correctly preserved.
- Try importing/pasting a very large raw text and observe slightly improved parsing times (less blocking).

---
*PR created automatically by Jules for task [9313252570356761161](https://jules.google.com/task/9313252570356761161) started by @Tugamer89*