### PR TITLE
fix(security): [security improvement] hide Nginx version information

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,6 +2,9 @@ server {
     listen 8080;
     server_name localhost;
 
+    # Security: Hide Nginx version
+    server_tokens off;
+
     root /usr/share/nginx/html;
     index index.html;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,7 +2,6 @@ server {
     listen 8080;
     server_name localhost;
 
-    # Security: Hide Nginx version
     server_tokens off;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
Severity: LOW/ENHANCEMENT
Vulnerability: Information Disclosure (Nginx Server Version).
Impact: Nginx broadcasts its exact version number in the HTTP headers (e.g., `Server: nginx/1.25.0`) and on default error pages. This information could be used by attackers to easily identify if the server is running an outdated version with known vulnerabilities.
Fix: Added the `server_tokens off;` directive to the `server` block in `nginx/nginx.conf`. This removes the version number from the `Server` header and error pages.
Verification: Verified the fix by running the unit tests and linting. In a running environment, executing `curl -I <server-url>` will now show `Server: nginx` instead of `Server: nginx/<version>`.

---
*PR created automatically by Jules for task [13935927584960743297](https://jules.google.com/task/13935927584960743297) started by @Tugamer89*