### PR TITLE
perf: optimize SRS date parsing in quiz generation

### DIFF
--- a/src/hooks/useQuizSession.js
+++ b/src/hooks/useQuizSession.js
@@ -29,6 +29,8 @@ export function useQuizSession(
         const includedSet = new Set(includedTags);
         const excludedSet = new Set(excludedTags);
 
+        const nowTime = Date.now();
+
         const eligible = questions.filter((q) => {
             if (q.deckId !== selectedDeckId) return false;
 
@@ -44,7 +46,7 @@ export function useQuizSession(
 
             if (settings.srsEnabled) {
                 if (!q.nextReviewDate) return true;
-                return new Date(q.nextReviewDate) <= new Date();
+                return new Date(q.nextReviewDate).getTime() <= nowTime;
             }
 
             return (


### PR DESCRIPTION
What: Extracted `Date.now()` calculation out of the `generateQuiz` filter loop.
Why: Previously, a new `Date` object was being instantiated twice for every iteration when checking if a review was due.
Impact: Avoids multiple unnecessary `Date` object instantiations when generating quizzes, improving CPU performance for decks with many questions.
Measurement: Compare loop execution time or JS heap usage before and after.

---
*PR created automatically by Jules for task [915935128195604947](https://jules.google.com/task/915935128195604947) started by @Tugamer89*