### PR TITLE
fix(security): input length limit enhancement for deck creation

### DIFF
--- a/src/hooks/useQuizData.js
+++ b/src/hooks/useQuizData.js
@@ -178,7 +178,17 @@ export function useQuizData(showToast, setDialog) {
             confirmStyle: 'primary',
             onConfirm: (name) => {
                 if (name?.trim()) {
-                    const newDeck = { id: crypto.randomUUID(), name: name.trim() };
+                    const trimmedName = name.trim();
+                    if (trimmedName.length > 100) {
+                        // Prevent LocalStorage exhaustion (Client-Side DoS)
+                        showToast('Deck name cannot exceed 100 characters.', 'error');
+                        return;
+                    }
+                    if (decks.some((d) => d.name === trimmedName)) {
+                        showToast('A deck with this name already exists.', 'error');
+                        return;
+                    }
+                    const newDeck = { id: crypto.randomUUID(), name: trimmedName };
                     setDecks((prev) => [...prev, newDeck]);
                     setSelectedDeckId(newDeck.id);
                     showToast(`Deck "${newDeck.name}" created!`, 'success');


### PR DESCRIPTION
### Severity: LOW/MEDIUM (Security Improvement)

### Vulnerability
The application previously allowed users to create decks with arbitrarily long names. Because Quiz Forge relies heavily on `LocalStorage`, this lack of boundary checking could be exploited (or accidentally triggered) to rapidly consume all available storage space, leading to a Client-Side Denial of Service (DoS) where the application can no longer save data or function properly.

### Impact
If `LocalStorage` is exhausted, the application would fail to persist new questions, settings, and study progress, effectively rendering the core features unusable for the user until they manually clear their browser data.

### Fix
Added input length validation in `src/hooks/useQuizData.js` within the `handleAddDeckClick` function. Deck names are now limited to 100 characters. If the user attempts to create a deck with a name exceeding this limit, the creation is blocked, and an error toast is displayed.
Additionally, added a check to prevent the creation of decks with duplicate names, further improving data hygiene and user experience.

### Verification
1. Run the local development server.
2. Attempt to create a new deck.
3. Paste a string longer than 100 characters into the prompt.
4. Verify that an error toast appears ("Deck name cannot exceed 100 characters.") and the deck is *not* created.
5. Attempt to create a deck with a name that already exists.
6. Verify that an error toast appears ("A deck with this name already exists.") and the duplicate deck is *not* created.

---
*PR created automatically by Jules for task [27418900023941436](https://jules.google.com/task/27418900023941436) started by @Tugamer89*