### PR TITLE
perf: defer search term filtering in DeckOverview

### DIFF
--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -21,7 +21,6 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
     const [excludedTags, setExcludedTags] = useState([]);
     const [expandedId, setExpandedId] = useState(null);
 
-    // Defers updating the filter until main thread is idle, preventing typing latency on large decks.
     const deferredSearchTerm = useDeferredValue(searchTerm);
 
     const allTags = useMemo(() => {

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, memo } from 'react';
+import { useState, useMemo, memo, useDeferredValue } from 'react';
 import PropTypes from 'prop-types';
 import {
     BookOpen,
@@ -21,6 +21,9 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
     const [excludedTags, setExcludedTags] = useState([]);
     const [expandedId, setExpandedId] = useState(null);
 
+    // Defers updating the filter until main thread is idle, preventing typing latency on large decks.
+    const deferredSearchTerm = useDeferredValue(searchTerm);
+
     const allTags = useMemo(() => {
         const tagsSet = new Set();
         for (const q of questions) {
@@ -34,11 +37,11 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
     }, [questions]);
 
     const filteredQuestions = useMemo(() => {
-        if (!searchTerm && includedTags.length === 0 && excludedTags.length === 0) {
+        if (!deferredSearchTerm && includedTags.length === 0 && excludedTags.length === 0) {
             return questions;
         }
 
-        const searchLower = searchTerm.toLowerCase();
+        const searchLower = deferredSearchTerm.toLowerCase();
         const includedSet = new Set(includedTags);
         const excludedSet = new Set(excludedTags);
 
@@ -49,14 +52,14 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
             if (excludedSet.size > 0 && q.tags?.some((t) => excludedSet.has(t))) {
                 return false;
             }
-            if (searchTerm) {
+            if (deferredSearchTerm) {
                 if (q.text.toLowerCase().includes(searchLower)) return true;
                 if (q.answer.toLowerCase().includes(searchLower)) return true;
                 return false;
             }
             return true;
         });
-    }, [questions, searchTerm, includedTags, excludedTags]);
+    }, [questions, deferredSearchTerm, includedTags, excludedTags]);
 
     const toggleTag = (tag) => {
         if (tag === null) {


### PR DESCRIPTION
**What:**
Wrapped the `searchTerm` state with React's `useDeferredValue` hook and updated the heavy filtering logic in `filteredQuestions` to rely on this deferred value inside `src/components/features/DeckOverview.jsx`. 

**Why:**
The application had an input field connected directly to a heavy filtering operation inside `DeckOverview.jsx` via `searchTerm`. As the deck size increases, triggering a complex recalculation of `filteredQuestions` on every single keystroke blocks the main thread, leading to a laggy, unresponsive input field.

**Impact:**
This ensures the input field stays immediately responsive to user keystrokes. The heavy filtering recalculations are deferred until the main thread is idle, significantly improving typing performance and overall perceived responsiveness.

**Measurement:**
1. Generate a massive test deck (thousands of cards).
2. Start typing rapidly into the "Search questions..." input field.
3. Observe that the input accepts characters without lag or stuttering, while the list below updates momentarily after you finish typing.

---
*PR created automatically by Jules for task [9285676623023450287](https://jules.google.com/task/9285676623023450287) started by @Tugamer89*