### PR TITLE
fix(ui): improve keyboard focus visibility on buttons

### DIFF
--- a/src/components/SummaryScreen.jsx
+++ b/src/components/SummaryScreen.jsx
@@ -86,7 +86,7 @@ export const SummaryScreen = memo(({ session, onReset, onPlayAgain }) => {
             <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4 border-t border-slate-100 dark:border-slate-800">
                 <button
                     onClick={onReset}
-                    className="flex items-center justify-center gap-2.5 px-8 py-3.5 rounded-xl border border-slate-300 dark:border-slate-600 bg-slate-200 hover:bg-slate-300 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-100 font-semibold transition-all duration-200 active:scale-95 group shadow-sm"
+                    className="flex items-center justify-center gap-2.5 px-8 py-3.5 rounded-xl border border-slate-300 dark:border-slate-600 bg-slate-200 hover:bg-slate-300 dark:bg-slate-700 dark:hover:bg-slate-600 text-slate-800 dark:text-slate-100 font-semibold transition-all duration-200 active:scale-95 group shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800"
                 >
                     <LogOut className="w-5 h-5 text-slate-500 group-hover:scale-110 transition-transform" />
                     Exit Quiz
@@ -94,7 +94,7 @@ export const SummaryScreen = memo(({ session, onReset, onPlayAgain }) => {
 
                 <button
                     onClick={() => onPlayAgain()}
-                    className="flex items-center justify-center gap-2.5 px-8 py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold transition-all duration-200 shadow-md shadow-indigo-200 dark:shadow-none active:scale-95 group focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-slate-800"
+                    className="flex items-center justify-center gap-2.5 px-8 py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold transition-all duration-200 shadow-md shadow-indigo-200 dark:shadow-none active:scale-95 group focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800"
                 >
                     <Zap className="w-5 h-5 group-hover:animate-pulse" aria-hidden="true" />
                     Play Again

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -140,7 +140,7 @@ export const Header = memo(({
 
                 <button
                     onClick={toggleTheme}
-                    className="p-2 rounded-full bg-white dark:bg-slate-800 shadow-sm border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    className="p-2 rounded-full bg-white dark:bg-slate-800 shadow-sm border border-slate-200 dark:border-slate-700 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800"
                     aria-label="Toggle Dark Theme"
                 >
                     {isDarkMode ? (


### PR DESCRIPTION
**What:**
Updated focus styles for several buttons (Theme Toggle, Exit Quiz, Play Again) to use `focus-visible` and consistent `ring-offset`.

**Why:**
To improve the keyboard navigation experience by providing clear, highly visible focus rings while avoiding unnecessary focus styles when the buttons are clicked with a mouse.

**Accessibility:**
This improves WCAG compliance for focus visibility and keyboard accessibility by ensuring interactive elements have distinct, consistent focus indicators that are visible against both light and dark backgrounds.

---
*PR created automatically by Jules for task [16340643920394086539](https://jules.google.com/task/16340643920394086539) started by @Tugamer89*