### PR TITLE
test(schemas): add test coverage for import schema validation

### DIFF
--- a/src/schemas/importSchema.test.js
+++ b/src/schemas/importSchema.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { deckSchema, questionSchema, importSchema } from './importSchema.js';
+
+describe('deckSchema', () => {
+    it('should validate a valid deck', () => {
+        const validDeck = { id: 'deck-1', name: 'My Deck' };
+        expect(() => deckSchema.parse(validDeck)).not.toThrow();
+    });
+
+    it('should fail if required fields are missing', () => {
+        const invalidDeck = { id: 'deck-1' }; // missing name
+        const result = deckSchema.safeParse(invalidDeck);
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('questionSchema', () => {
+    it('should validate a valid minimal question and apply defaults', () => {
+        const validQuestion = {
+            id: 'q-1',
+            text: 'Question text',
+            answer: 'Answer text',
+            deckId: 'deck-1',
+        };
+        const parsed = questionSchema.parse(validQuestion);
+        expect(parsed.status).toBe('unanswered');
+        expect(parsed.tags).toEqual([]);
+    });
+
+    it('should validate a fully populated question', () => {
+        const fullQuestion = {
+            id: 'q-1',
+            number: '1',
+            text: 'Question text',
+            answer: 'Answer text',
+            status: 'correct',
+            deckId: 'deck-1',
+            tags: ['tag1', 'tag2'],
+            easeFactor: 2.5,
+            interval: 1,
+            repetition: 0,
+            nextReviewDate: '2023-01-01',
+        };
+        expect(() => questionSchema.parse(fullQuestion)).not.toThrow();
+    });
+
+    it('should fail if invalid status is provided', () => {
+        const invalidQuestion = {
+            id: 'q-1',
+            text: 'Question text',
+            answer: 'Answer text',
+            deckId: 'deck-1',
+            status: 'invalid-status',
+        };
+        const result = questionSchema.safeParse(invalidQuestion);
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('importSchema', () => {
+    it('should validate a valid import object', () => {
+        const validImport = {
+            decks: [{ id: 'deck-1', name: 'Deck 1' }],
+            questions: [
+                {
+                    id: 'q-1',
+                    text: 'Q1',
+                    answer: 'A1',
+                    deckId: 'deck-1',
+                },
+            ],
+            rawTexts: { 'deck-1': 'some raw text' },
+        };
+        expect(() => importSchema.parse(validImport)).not.toThrow();
+    });
+
+    it('should fail if decks or questions are missing', () => {
+        const invalidImport = {
+            decks: [{ id: 'deck-1', name: 'Deck 1' }],
+        }; // missing questions
+        const result = importSchema.safeParse(invalidImport);
+        expect(result.success).toBe(false);
+    });
+
+    it('should fail if nested schema validation fails', () => {
+        const invalidImport = {
+            decks: [{ id: 'deck-1' }], // missing deck name
+            questions: [],
+        };
+        const result = importSchema.safeParse(invalidImport);
+        expect(result.success).toBe(false);
+    });
+});


### PR DESCRIPTION
**What:** Missing tests for import schema validation, specifically for `deckSchema`, `questionSchema`, and `importSchema`.

**Coverage:** Added tests to cover the following scenarios:
- `deckSchema`: Validation of valid decks and detection of missing required fields (`id`, `name`).
- `questionSchema`: Application of defaults (`status`, `tags`), validation of minimal/fully populated objects, and rejection of invalid `status` enum values.
- `importSchema`: Validation of full import payload structure including `decks`, `questions`, and `rawTexts`, as well as failures for missing outer structures and inner schema failures.

**Result:** Improved reliability and confidence in the import schema validations by verifying it behaves as expected and rejects invalid payloads. Test coverage in `importSchema.js` has significantly increased.

---
*PR created automatically by Jules for task [17781348713188636454](https://jules.google.com/task/17781348713188636454) started by @Tugamer89*