### PR TITLE
feat(ui): add focus visible styling to dropdown menu buttons

### DIFF
--- a/src/components/features/CloudSync.jsx
+++ b/src/components/features/CloudSync.jsx
@@ -185,7 +185,7 @@ export const CloudSync = ({
                     key={text}
                     onClick={() => handleAuth(action)}
                     disabled={isSyncing}
-                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed group"
+                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed group"
                     title={title}
                 >
                     {isSyncing ? (

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -101,14 +101,14 @@ export const Header = memo(({
                                 />
                                 <button
                                     onClick={() => fileInputRef.current?.click()}
-                                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-700"
                                 >
                                     <Upload className="w-4 h-4 mr-2.5 text-slate-500 dark:text-slate-400" />
                                     Import Backup
                                 </button>
                                 <button
                                     onClick={handleExportWrapper}
-                                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+                                    className="w-full flex items-center px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-700"
                                 >
                                     <Download className="w-4 h-4 mr-2.5 text-slate-500 dark:text-slate-400" />
                                     Export Backup


### PR DESCRIPTION
What: Added `focus-visible` styling to the "Import Backup", "Export Backup", and cloud sync action buttons within the dropdown menus.
Why: Previously, keyboard users tabbing through the "Data & Sync" dropdown had no visual indication of which button was focused, making navigation difficult and less intuitive.
Accessibility: Improved keyboard navigation by adding clear focus rings or background highlights for users navigating the UI with a keyboard.

---
*PR created automatically by Jules for task [15338812010514949465](https://jules.google.com/task/15338812010514949465) started by @Tugamer89*