### PR TITLE
fix(security): input length limits

### DIFF
--- a/src/components/CustomDialog.jsx
+++ b/src/components/CustomDialog.jsx
@@ -82,6 +82,7 @@ CustomDialog.propTypes = {
         icon: PropTypes.node,
         message: PropTypes.string,
         defaultValue: PropTypes.string,
+        maxLength: PropTypes.number,
         confirmLabel: PropTypes.string,
         confirmStyle: PropTypes.oneOf(['primary', 'danger']),
         onConfirm: PropTypes.func.isRequired,

--- a/src/components/CustomDialog.jsx
+++ b/src/components/CustomDialog.jsx
@@ -50,6 +50,7 @@ export const CustomDialog = memo(({ dialog, onClose }) => {
                     value={inputVal}
                     onChange={(e) => setInputVal(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && handleConfirm()}
+                    maxLength={dialog.maxLength || 255}
                     className="w-full p-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-white focus:ring-2 focus:ring-indigo-500 outline-none mb-4"
                 />
             )}

--- a/src/components/features/DeckOverview.jsx
+++ b/src/components/features/DeckOverview.jsx
@@ -81,6 +81,7 @@ export const DeckOverview = memo(({ questions, stats, onMarkQuestion, onGenerate
                             aria-label="Search questions"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
+                            maxLength={100}
                             className="w-full pl-10 pr-4 py-2 bg-slate-50 dark:bg-slate-900 border border-slate-300 dark:border-slate-600 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 outline-none transition-colors dark:text-white"
                         />
                     </div>

--- a/src/hooks/useQuizData.js
+++ b/src/hooks/useQuizData.js
@@ -172,6 +172,7 @@ export function useQuizData(showToast, setDialog) {
             title: 'New Deck',
             message: 'Enter a name for your new deck:',
             defaultValue: '',
+            maxLength: 100,
             confirmLabel: 'Create',
             confirmStyle: 'primary',
             onConfirm: (name) => {


### PR DESCRIPTION
Severity: MEDIUM

Vulnerability: Missing input length limits on text inputs (such as search boxes and prompt dialogs) allows users to paste excessively large strings.
Impact: Processing very large strings can cause the browser to freeze or crash, resulting in a client-side Denial of Service (DoS).
Fix: Added `maxLength` properties to the `CustomDialog` component, the deck creation prompt in `useQuizData.js`, and the search input in `DeckOverview.jsx`.
Verification: Verified by running all unit tests (`pnpm test`) and linting (`pnpm run lint`). The `maxLength` attribute is now correctly applied to the HTML inputs.

---
*PR created automatically by Jules for task [10135843012169436174](https://jules.google.com/task/10135843012169436174) started by @Tugamer89*