### PR TITLE
feat(ui): add disabled state and tooltip to Delete Deck button

### DIFF
--- a/src/components/features/SidebarControls.jsx
+++ b/src/components/features/SidebarControls.jsx
@@ -88,9 +88,10 @@ export const SidebarControls = memo(({
                     </button>
                     <button
                         onClick={onDeleteDeck}
+                        disabled={decks.length <= 1}
                         aria-label="Delete Deck"
-                        title="Delete Deck"
-                        className="p-2 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 rounded-lg transition-colors"
+                        title={decks.length <= 1 ? "Cannot delete the last deck" : "Delete Deck"}
+                        className="p-2 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
                     >
                         <Trash2 className="w-5 h-5" />
                     </button>


### PR DESCRIPTION
**What:**
Disabled the Delete Deck button when there is only one deck present.

**Why:**
To prevent users from accidentally deleting their last deck.

**Before/After:**
Before, the button was visually active, and clicking it showed an error toast.
After, the button is visually disabled (opacity reduced, cursor changed) and has a helpful tooltip explaining why it cannot be deleted.

**Accessibility:**
The button's native `title` attribute communicates the disabled state to users, serving as a tooltip on hover. Added `disabled` attribute directly to the button element.

---
*PR created automatically by Jules for task [17288464171075459745](https://jules.google.com/task/17288464171075459745) started by @Tugamer89*