### PR TITLE
perf: optimize string search in filterQuestions

### DIFF
--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -35,10 +35,9 @@ export function filterQuestions(questions, searchTerm, includedTags, excludedTag
         return questions;
     }
 
-    // Optimization: Use RegExp for faster case-insensitive searching instead of allocating lowercased strings
     let searchRegex = null;
     if (searchTerm) {
-        const escapedSearch = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const escapedSearch = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
         searchRegex = new RegExp(escapedSearch, 'i');
     }
 

--- a/src/utils/helpers.jsx
+++ b/src/utils/helpers.jsx
@@ -35,7 +35,13 @@ export function filterQuestions(questions, searchTerm, includedTags, excludedTag
         return questions;
     }
 
-    const searchLower = searchTerm.toLowerCase();
+    // Optimization: Use RegExp for faster case-insensitive searching instead of allocating lowercased strings
+    let searchRegex = null;
+    if (searchTerm) {
+        const escapedSearch = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        searchRegex = new RegExp(escapedSearch, 'i');
+    }
+
     const includedSet = new Set(includedTags);
     const excludedSet = new Set(excludedTags);
 
@@ -46,10 +52,8 @@ export function filterQuestions(questions, searchTerm, includedTags, excludedTag
         if (excludedSet.size > 0 && q.tags?.some((t) => excludedSet.has(t))) {
             return false;
         }
-        if (searchTerm) {
-            if (q.text.toLowerCase().includes(searchLower)) return true;
-            if (q.answer.toLowerCase().includes(searchLower)) return true;
-            return false;
+        if (searchRegex) {
+            return searchRegex.test(q.text) || searchRegex.test(q.answer);
         }
         return true;
     });


### PR DESCRIPTION
What: Refactored `filterQuestions` to use a pre-compiled case-insensitive `RegExp` instead of repeatedly allocating lowercased strings inside a loop.
Why: The previous implementation performed `.toLowerCase()` on both `q.text` and `q.answer` for every question on every filter pass, creating a large number of temporary string allocations and causing performance overhead during search operations on large datasets.
Impact: Reduces memory allocation and speeds up filtering on large decks.
Measurement: Run `pnpm test:run` to verify that `src/utils/helpers.test.jsx` still passes successfully.

---
*PR created automatically by Jules for task [15345129137133430267](https://jules.google.com/task/15345129137133430267) started by @Tugamer89*