### PR TITLE
feat(ui): improve keyboard accessibility and screen reader support in sidebar

### DIFF
--- a/src/components/features/SidebarControls.jsx
+++ b/src/components/features/SidebarControls.jsx
@@ -82,7 +82,7 @@ export const SidebarControls = memo(({
                         onClick={onAddDeck}
                         aria-label="Add Deck"
                         title="Add Deck"
-                        className="p-2 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-200 dark:hover:bg-indigo-900 rounded-lg transition-colors"
+                        className="p-2 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-200 dark:hover:bg-indigo-900 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                     >
                         <Plus className="w-5 h-5" />
                     </button>
@@ -91,7 +91,7 @@ export const SidebarControls = memo(({
                         disabled={decks.length <= 1}
                         aria-label="Delete Deck"
                         title={decks.length <= 1 ? "Cannot delete the last deck" : "Delete Deck"}
-                        className="p-2 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+                        className="p-2 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/50 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                     >
                         <Trash2 className="w-5 h-5" />
                     </button>
@@ -121,7 +121,7 @@ export const SidebarControls = memo(({
                             onClick={() => insertFormatting('**', '**')}
                             aria-label="Bold text"
                             title="Bold"
-                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors"
+                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                         >
                             <Bold className="w-4 h-4" />
                         </button>
@@ -129,7 +129,7 @@ export const SidebarControls = memo(({
                             onClick={() => insertFormatting('*', '*')}
                             aria-label="Italic text"
                             title="Italics"
-                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors"
+                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                         >
                             <Italic className="w-4 h-4" />
                         </button>
@@ -137,7 +137,7 @@ export const SidebarControls = memo(({
                             onClick={() => insertFormatting('`', '`')}
                             aria-label="Inline code"
                             title="Inline code"
-                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors"
+                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                         >
                             <CodeIcon className="w-4 h-4" />
                         </button>
@@ -145,13 +145,14 @@ export const SidebarControls = memo(({
                             onClick={() => insertFormatting('```\n', '\n```')}
                             aria-label="Code block"
                             title="Code block"
-                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors text-xs font-mono font-bold"
+                            className="p-1.5 text-slate-600 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700 rounded transition-colors text-xs font-mono font-bold focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                         >
                             {`</>`}
                         </button>
                     </div>
                     <textarea
                         ref={textareaRef}
+                        aria-label="Raw text input"
                         className="w-full h-48 p-3 text-sm bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 outline-none resize-none placeholder:text-slate-400 dark:placeholder:text-slate-500 font-mono border-0"
                         placeholder="1. Markdown works! #hashtag&#10;Use **bold**, *italic*, and `code`.&#10;&#10;2. Another question?&#10;The answer goes here..."
                         value={currentRawText}
@@ -163,7 +164,7 @@ export const SidebarControls = memo(({
                         onClick={onCopyText}
                         disabled={!currentRawText}
                         title={currentRawText ? 'Copy text' : 'Add text to copy'}
-                        className="flex-1 flex items-center justify-center space-x-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed font-medium py-2 px-4 rounded-lg transition-colors text-sm"
+                        className="flex-1 flex items-center justify-center space-x-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-slate-700 dark:text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed font-medium py-2 px-4 rounded-lg transition-colors text-sm focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                     >
                         <Copy className="w-4 h-4" /> <span>Copy</span>
                     </button>
@@ -172,7 +173,7 @@ export const SidebarControls = memo(({
                         disabled={!currentRawText}
                         aria-label="Erase all text"
                         title={currentRawText ? 'Clear' : 'Add text to clear'}
-                        className="flex-none p-2.5 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/80 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+                        className="flex-none p-2.5 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/80 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                     >
                         <Eraser className="w-5 h-5" />
                     </button>
@@ -312,7 +313,7 @@ export const SidebarControls = memo(({
                                 ? 'Add questions to this deck to start a quiz'
                                 : 'Start Quiz'
                         }
-                        className="w-full mt-4 flex items-center justify-center space-x-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-lg transition-all shadow-sm active:scale-[0.98]"
+                        className="w-full mt-4 flex items-center justify-center space-x-2 bg-indigo-600 hover:bg-indigo-700 disabled:bg-slate-300 dark:disabled:bg-slate-700 disabled:text-slate-500 disabled:cursor-not-allowed text-white font-medium py-3 px-4 rounded-lg transition-all shadow-sm active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 focus:outline-none"
                     >
                         <Play className="w-5 h-5 fill-current" />
                         <span>Start Quiz</span>


### PR DESCRIPTION
What: Improved accessibility for the SidebarControls component by adding missing ARIA labels and focus rings.
Why: Screen readers couldn't identify the main raw text input, and keyboard users lacked clear focus indication on the sidebar's interactive buttons.
Before/After: Interactive buttons now have distinct indigo (or red for destructive actions) focus rings when tabbed to.
Accessibility: Added aria-label="Raw text input" to the textarea and focus-visible:ring-2 classes to 9 interactive buttons.

---
*PR created automatically by Jules for task [6376742952453624604](https://jules.google.com/task/6376742952453624604) started by @Tugamer89*